### PR TITLE
Fix Subtotal Calculation in Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the shopping cart's subtotal of items was incorrectly calculated by concatenating the item quantities instead of summing them up. The root cause was identified as the treatment of item quantities ('qty') as strings during the reduction process in the CartScreen component. By parsing 'qty' as an integer before addition, the subtotal now correctly reflects the sum of item quantities.

**Issue Description:** Within the shopping cart functionality, adjusting the quantity of items led to the incorrect calculation of the 'subtotal _ items' feature, where quantities were concatenated instead of summed.

**Solution:** The solution involved modifying the reduce function within the 'CartScreen.js' file to ensure 'c.qty' is treated as an integer, changing the code to 'cartItems.reduce((a, c) => a + parseInt(c.qty), 0)'. This modification forces the 'qty' value to be an integer, enabling correct summation of item quantities.

**Impact:** Resolving this issue significantly improves the user experience by providing accurate information about the total number of items in the cart, preventing confusion and potential checkout errors, thereby enhancing the application's reliability and accuracy in order processing and inventory management.

**Steps to Reproduce:**
1. Add multiple items to the shopping cart.
2. Change the quantity of at least one item to a number greater than 1.
3. Observe the 'subtotal _ items' display, noting that the quantities are now correctly summed.

This fix has been thoroughly tested, ensuring that the subtotal is accurately calculated regardless of the individual quantities selected for each item in the cart.