### PR TITLE
Fix Subtotal Calculation Error in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This PR addresses a critical bug identified in the shopping cart functionality of our e-commerce platform, where the calculation of the subtotal number of items was incorrect due to the quantities being treated as strings during concatenation. The issue manifested when a user adjusted the quantities of items in their cart, leading to inaccurate subtotal displays. 

**Issue Description:** When changing the quantity of items in the shopping cart, the system erroneously concatenated the values instead of correctly adding them, displaying incorrect subtotal numbers of items. 

**Resolution:** The bug was fixed by ensuring that the quantities are treated as numeric values during the subtotal calculation. This was achieved by modifying the line of code in 'frontend/src/screens/CartScreen.js' from 'cartItems.reduce((a, c) => a + c.qty, 0)' to 'cartItems.reduce((a, c) => a + Number(c.qty), 0)'. This change correctly calculates the subtotal number of items as integers. 

**Impact:** This resolution significantly improves the user experience by providing accurate subtotal calculations, restoring trust in the shopping cart's accuracy, and potentially increasing the likelihood of users completing their purchases. 

This change has been thoroughly tested to ensure that it resolves the issue without introducing any new bugs. Your review and approval of this PR would be greatly appreciated.