### PR TITLE
Fix issue in shopping cart screen where Subtotal price is showing incorrect amount

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -39,7 +39,7 @@ function CartScreen(props) {
           cartItems.length === 0 ?
             <div>
               Cart is empty
-          </div>
+            </div>
             :
             cartItems.map(item =>
               <li>
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                    <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + Number(c.price) * Number(c.qty), 0).toFixed(2)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request resolves a critical issue identified on the shopping cart screen, where the subtotal price was inaccurately calculated. Instead of displaying the correct total price based on the quantity and price of the items in the cart, the subtotal mistakenly showed the total quantity of items. 

**Issue Description:** Users encountered a problem on the shopping cart screen where the subtotal price was incorrectly calculated, showing the total item count instead of the total price. For example, adding two items priced at $90 each to their cart should result in a subtotal of $180. Instead, the subtotal displayed as $2, reflecting the item count. 

**Resolution:** The bug was traced to an incorrect calculation of the subtotal in 'CartScreen.js'. The issue arose from how the subtotal price was calculated and displayed. The problem was fixed by ensuring the 'reduce' function properly multiplies each item's price by its quantity before summing it up across all items, and verifying that both 'c.price' and 'c.qty' are treated as numerical values during the calculation. 

**Impact:** This issue severely impacted the user experience and could have led to confusion and potential loss of sales. Resolving this bug was crucial for the integrity of the checkout process and the overall trust in our platform. 

This fix has been tested with multiple products to ensure the subtotal reflects the correct total price based on the quantity and price of the items added.