### PR TITLE
Resolve Incorrect Subtotal Calculation in Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses and resolves the issue where the cart's subtotal of items was incorrectly calculated due to the quantities being concatenated as strings instead of being summed as integers. The resolution involved ensuring that item quantities are explicitly converted to numbers before performing the addition operation. Changes were made in the 'CartScreen.js' file to use 'Number(c.qty)' in the reduce function for calculating subtotals, thereby ensuring accurate arithmetic operations.

**Impact**: This fix significantly enhances the user experience by providing accurate information regarding the total number of items in the cart, mitigating confusion and potential mistrust in the application's reliability.

**Tested Scenarios**:
- Adding multiple items to the shopping cart.
- Changing the quantity of one or more items in different combinations.
- Verifying that the displayed subtotal correctly reflects the total quantity of items.

This change has been thoroughly tested, and the issue of incorrect subtotal calculation due to string concatenation has been resolved.