### PR TITLE
Fix: Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the bug described in the ticket regarding the incorrect subtotal calculation in the shopping cart. When users modified the quantity of any item in their cart, the subtotal would incorrectly concatenate quantities as strings instead of calculating the correct sum.

**Issue Description:** The subtotal displayed did not correctly update to reflect the new total quantity of items due to a type mismatch, treating quantity values as strings.

**Resolution:** The issue was resolved by ensuring all quantity values are parsed to integers before performing addition operations. This involved modifying the `reduce` function used for calculating the subtotal in the `CartScreen.js` file to parse the `qty` value as an integer.

**Impact:** This fix significantly improves the user experience by providing accurate information about the total number of items in the shopping cart, thereby restoring trust in the platform's shopping process.