### PR TITLE
Fix Subtotal Calculation in Shopping Cart Screen

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -78,7 +78,7 @@ function CartScreen(props) {
       <h3>
         Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0).toFixed(2)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request resolves an issue in the shopping cart screen where the subtotal price was incorrectly calculated, displaying the total count of items instead of their combined price. The fix involved correcting the subtotal calculation logic within the 'CartScreen.js' file to ensure the subtotal now accurately reflects the total price of all items in the cart.

**Issue Description:** In the shopping cart screen, the subtotal price was erroneously displaying the total count of items, not their total price. For example, adding two items priced at $90 each would result in a subtotal of $2, instead of the correct $180.

**Solution:** Modified the calculation logic in the 'cart-action' div to sum up the product of each item's price and quantity, ensuring the subtotal correctly reflects the total price.

**Impact:** This fix significantly improves the checkout process and user experience by providing clear and correct pricing information, thereby fostering user trust and potentially increasing sales.