### PR TITLE
Fix issue in shopping cart screen where Subtotal price is coming wrong

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -78,7 +78,7 @@ function CartScreen(props) {
       <h3>
         Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0).toFixed(2)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the bug described in the ticket that affects the shopping cart screen, where the Subtotal price displayed is incorrect. The issue was that the Subtotal displayed the total count of items in the cart rather than the total price of these items. The resolution involved correcting the subtotal calculation in the 'CartScreen.js' file to ensure that the Subtotal reflects the sum of the products' prices multiplied by their quantities. This fix aligns the functionality with the expected result, thereby improving the user experience and integrity of the checkout process.