### PR TITLE
Fix Subtotal Concatenation Bug in Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the subtotal in the cart was incorrectly displaying concatenated values instead of the sum of item quantities. The problem was due to the quantity values being treated as strings during arithmetic operations. The solution involved ensuring that the quantity values are treated as integers in the subtotal calculation. Changes were made in the 'CartScreen.js' file to correctly sum the quantities using either the Number() function or the unary plus operator. This fix ensures the subtotal now accurately reflects the sum of the quantities of all items in the cart, improving user experience and maintaining integrity in the shopping process.