### PR TITLE
Resolve Incorrect Subtotal Calculation in Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -18,7 +18,7 @@ function CartScreen(props) {
     if (productId) {
       dispatch(addToCart(productId, qty));
     }
-  }, []);
+  }, [dispatch, productId, qty]);
 
   const checkoutHandler = () => {
     props.history.push("/signin?redirect=shipping");
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses a high-priority bug identified in the shopping cart module of our e-commerce platform. The bug caused item quantities in the cart to concatenate instead of summing up correctly when a user adjusted them, leading to incorrect subtotal item counts. For example, adjusting item quantities of 1, 2, and 1 would incorrectly display a subtotal of '121 items' due to quantity values being treated as strings.

**Issue Description:**
Within the shopping cart, adjusting the quantities of items led to the subtotal item count improperly concatenating the quantity values instead of summing them, due to the quantities being treated as strings during arithmetic operations.

**Resolution:**
The bug was resolved by ensuring the quantity is explicitly converted to an integer before the addition operation in the cart's subtotal calculation. This was implemented by modifying the `reduce` function in `CartScreen.js` to use `Number(c.qty)` for quantity adjustments, ensuring accurate subtotal calculations.

**Impact:**
This fix significantly improves the user experience by providing accurate information about the total number of items within the cart, ensuring integrity in the application's shopping cart functionality and maintaining user trust in the checkout process.