### PR TITLE
Fix Incorrect Calculation of 'Subtotal _ Items' in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -2,23 +2,24 @@ import React, { useEffect } from 'react';
 import { addToCart, removeFromCart } from '../actions/cartActions';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
+
 function CartScreen(props) {
 
   const cart = useSelector(state => state.cart);
-
   const { cartItems } = cart;
-
   const productId = props.match.params.id;
   const qty = props.location.search ? Number(props.location.search.split("=")[1]) : 1;
   const dispatch = useDispatch();
+
   const removeFromCartHandler = (productId) => {
     dispatch(removeFromCart(productId));
   }
+
   useEffect(() => {
     if (productId) {
       dispatch(addToCart(productId, qty));
     }
-  }, []);
+  }, [dispatch, productId, qty]);
 
   const checkoutHandler = () => {
     props.history.push("/signin?redirect=shipping");
@@ -39,10 +40,10 @@ function CartScreen(props) {
           cartItems.length === 0 ?
             <div>
               Cart is empty
-          </div>
+            </div>
             :
             cartItems.map(item =>
-              <li>
+              <li key={item.product}>
                 <div className="cart-image">
                   <img src={item.image} alt="product" />
                 </div>
@@ -51,11 +52,10 @@ function CartScreen(props) {
                     <Link to={"/product/" + item.product}>
                       {item.name}
                     </Link>
-
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                    <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -72,20 +72,17 @@ function CartScreen(props) {
             )
         }
       </ul>
-
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
-        :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
+        : 
+        $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout
       </button>
-
     </div>
-
   </div>
 }
 


### PR DESCRIPTION
This PR resolves an issue where adjusting the quantity of items in the shopping cart resulted in incorrect 'subtotal _ items' calculations. The bug was due to the application concatenating quantity values instead of summing them, treating the quantities as strings. The resolution involved ensuring quantity values are correctly summed as integers by modifying the code in 'CartScreen.js' to use 'Number(c.qty)' in the subtotal calculation. This fix addresses the incorrect display of item quantities in the cart and ensures the application accurately calculates the 'subtotal _ items'.

**Resolved Ticket**: Incorrect Calculation of 'Subtotal _ Items' in Shopping Cart

**Issue Description**: The application incorrectly calculated the 'subtotal _ items' value by concatenating the quantity values instead of summing them, affecting user experience and potentially the checkout process.

**Steps to Reproduce**:
1. Add multiple items to the shopping cart.
2. Adjust the quantity of at least one item to a value greater than 1.
3. Observe the incorrect 'subtotal _ items' value.

**Development Plan**:
- Corrected the subtotal items calculation by ensuring the quantity values are summed as integers in 'CartScreen.js'.

**Testing**:
- Functionality was tested by adjusting item quantities in the cart, verifying that the subtotal items count is now correctly calculated and displayed.