### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the shopping cart's subtotal count was incorrectly calculated due to the 'qty' field being treated as a string, leading to string concatenation instead of numeric addition. The resolution involved ensuring that 'c.qty' is treated as an integer within the reduce function used to calculate the subtotal. Changes were made in '/Users/abhishek/code/octo/octo/repos/node-react-ecommerce/frontend/src/screens/CartScreen.js', converting 'c.qty' to an integer using the parseInt function. This fix corrects the subtotal calculation, accurately reflecting the sum of item quantities in the shopping cart.

**Issue Description:** In the shopping cart module, adjusting item quantities led to an incorrect subtotal count due to string concatenation of quantities. This was resolved by ensuring quantities are treated as integers during the subtotal calculation.

**Impact:** This bug significantly affected the user experience by providing misleading information about the total item count, potentially leading to checkout errors. With this fix, the integrity of the shopping cart's functionality is restored, enhancing the overall user experience.