### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, parseInt(e.target.value, 10)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses a bug identified in the e-commerce platform's shopping cart, where changing the quantity of items led to incorrect subtotal calculations. The issue was caused by the 'qty' values being concatenated as strings rather than summed as integers.

**Issue Description:**
When a user changes the quantity of items in their shopping cart, the expected behavior is for the subtotal to correctly reflect the sum of quantities as integers. However, due to a bug, changing item quantities resulted in the quantities being concatenated as strings, leading to incorrect subtotal displays (e.g., '121 items' instead of '4 items').

**Resolution:**
To resolve this issue, the 'qty' value is now explicitly parsed as an integer before being added to the subtotal. This change was made in the file `/app/octoplus/octo/repos/node-react-ecommerce/frontend/src/screens/CartScreen.js` by updating the line responsible for calculating the subtotal to `Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)`. This ensures that the quantities are always summed up as integers, thus preventing the incorrect concatenation behavior.

This fix enhances the user experience by providing accurate information about the total number of items in the cart, thereby maintaining the integrity of the application's cart management and checkout processes.