### PR TITLE
Fix Incorrect Calculation of Subtotal in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the shopping cart feature was incorrectly calculating the subtotal and total price of items due to quantity values being treated as strings. Changes were made in the CartScreen.js file to ensure that quantity values are parsed as integers during calculations.

**Key Changes:**
- Modified the `reduce` function call within the JSX that renders the cart subtotal to parse `c.qty` as an integer.
- Applied a similar fix to the `reduce` function that calculates the total price, ensuring quantities are correctly parsed as integers.

These changes correct the subtotal and total price calculation, enhancing the reliability of our e-commerce platform and ensuring a positive user experience.