### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + Number(c.qty), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the shopping cart's subtotal count was incorrectly calculated by concatenating item quantities as strings rather than summing them numerically. The bug was fixed by ensuring that the `qty` value is converted to a number before performing the addition in the `reduce` function call within `CartScreen.js`. Steps to reproduce the bug and the expected result were provided in the ticket. This fix is expected to improve user experience by displaying accurate subtotal counts and thereby restoring trust in the cart's calculation accuracy.

**Issue Description:**
In the e-commerce platform's shopping cart, adjusting item quantities led to the subtotal count being incorrectly calculated due to string concatenation of quantities. This resulted in misleading subtotal counts displayed to the user.

**Resolution:**
The fix involved modifying the subtotal calculation to convert item quantities to numbers before addition, ensuring accurate calculation of the subtotal count.

**Testing:**
Adjusting the quantities of items in the shopping cart now accurately reflects the sum of the quantities, correcting the previously erroneous behavior.