### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,7 +76,7 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
          $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
       </h3>


### PR DESCRIPTION
This pull request addresses the issue described in the ticket regarding the incorrect subtotal calculation in the shopping cart. Previously, adjusting the quantities of items in the cart led to the quantities being concatenated as strings, resulting in incorrect subtotal displays (e.g., '121 items' instead of '4 items').

**Issue Description:**
In the shopping cart functionality, when a user adjusts the quantity of items, the subtotal count of items incorrectly concatenates the numbers instead of summing them up. This was due to the 'qty' (quantity) value being treated as a string when changed.

**Resolution:**
The fix involves ensuring that 'c.qty' is converted to an integer before performing the addition in the subtotal calculation. This was achieved by modifying the code in `/app/octoplus/octo/repos/node-react-ecommerce/frontend/src/screens/CartScreen.js` to use `parseInt(c.qty)` within the `reduce` function for the subtotal calculation.

The corrected line of code now reads: `subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty), 0)} items)`, ensuring that item quantities are correctly summed up, thus providing the accurate subtotal of items in the cart.

This change corrects the arithmetic operation used to calculate the subtotal, ensuring that item quantities are correctly summed up irrespective of their initial type. The resolution of this issue significantly improves the user experience by providing accurate information about the total number of items in the cart, thereby preventing confusion during the shopping process.