### PR TITLE
Fix Incorrect Subtotal Calculation in Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -42,7 +42,7 @@ function CartScreen(props) {
           </div>
             :
             cartItems.map(item =>
-              <li>
+              <li key={item.product}>
                 <div className="cart-image">
                   <img src={item.image} alt="product" />
                 </div>
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue described in the ticket regarding the incorrect subtotal calculation in the shopping cart. Previously, item quantities were concatenated as strings instead of being summed up as integers, leading to incorrect subtotal displays (e.g., 'subtotal 121 items' instead of '4 items').

**Issue Description:** In the shopping cart, adjusting the quantities of items led to a miscalculation of the subtotal count displayed at the bottom of the cart. Instead of summing the item quantities as integers, the application concatenated them as strings.

**Resolution:** The code responsible for calculating the subtotal has been updated. The `cartItems.reduce((a, c) => a + c.qty, 0)` line in `/frontend/src/screens/CartScreen.js` was modified to `cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)`, thereby ensuring `c.qty` is treated as an integer before addition.

**Impact:** This fix significantly improves user experience by providing accurate information about the total number of items in the cart, ensuring transparency and trust in the e-commerce process.

**Testing:** The functionality was tested by adjusting the quantities of items in the cart to verify that the subtotal now correctly represents the sum of the item quantities as integers.

This change addresses the core issue and follows the recommended development plan for bug resolution.