### PR TITLE
Fix incorrect subtotal calculation in shopping cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,7 +76,7 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
          $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
       </h3>


### PR DESCRIPTION
This pull request addresses the issue where the subtotal count of items in the shopping cart was not updating correctly due to the quantities being concatenated as strings rather than summed as integers. The fix ensures that the `qty` property is parsed as an integer before performing the addition operation. This resolves the bug and now the subtotal correctly reflects the sum of item quantities in the cart.

**Resolved Issue:** Incorrect subtotal calculation when adjusting item quantities in the shopping cart.

**Steps to Reproduce:**
1. Add multiple items to the shopping cart.
2. Adjust the quantity of one or more items.
3. Observe the correct subtotal item count displayed in the cart.

**Development Fix:** The solution involved modifying the reduce function in `/app/octoplus/octo/repos/node-react-ecommerce/frontend/src/screens/CartScreen.js` to parse each item's quantity as an integer before summing. The updated expression is `cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)`, ensuring accurate arithmetic addition.