### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where the subtotal displayed in the shopping cart concatenates quantity values as strings rather than calculating the correct sum of items, leading to incorrect subtotal information. The resolution involves modifying the subtotal calculation in the CartScreen component to ensure that quantity values are correctly parsed as integers before summing them up. This change corrects the subtotal display to reflect the accurate total quantity of items in the cart, enhancing the user experience by providing reliable information essential for e-commerce transactions.

**Ticket**: Incorrect subtotal calculation in shopping cart

**Issue Description**: When adjusting the quantity of items in the cart, the subtotal displayed concatenates the quantity values as strings, resulting in incorrect information.

**Expected Result**: The application should correctly calculate and display the subtotal quantity as the sum of all item quantities in the cart.

**Steps to Reproduce**:
1. Add multiple items to the shopping cart.
2. Adjust the quantity of one or more items.
3. Observe the incorrect subtotal displayed.

**Technical Details**: The fix involved ensuring that 'cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)' is used for calculation, to correctly parse quantity values as integers.

**Impact**: This bug significantly impacted the user experience by displaying incorrect subtotal information. With this fix, users will now see accurate subtotal calculations, crucial for making informed purchasing decisions.