### PR TITLE
Fix Incorrect Subtotal Calculation in Cart

### DIFF
--- a/frontend/src/frontend/src/screens/CartScreen.js
+++ b/frontend/src/frontend/src/screens/CartScreen.js
@@ -1,0 +1,110 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { addToCart, removeFromCart } from '../actions/cartActions';
+import MessageBox from '../components/MessageBox';
+
+function CartScreen(props) {
+    const productId = props.match.params.id;
+    const qty = props.location.search
+        ? Number(props.location.search.split('=')[1])
+        : 1;
+    const cart = useSelector((state) => state.cart);
+    const { cartItems } = cart;
+    const dispatch = useDispatch();
+    useEffect(() => {
+        if (productId) {
+            dispatch(addToCart(productId, qty));
+        }
+    }, [dispatch, productId, qty]);
+
+    const removeFromCartHandler = (id) => {
+        // dispatch remove from cart action
+        dispatch(removeFromCart(id));
+    };
+
+    const checkoutHandler = () => {
+        props.history.push('/signin?redirect=shipping');
+    };
+
+    return (
+        <div className="row top">
+            <div className="col-2">
+                <h1>Shopping Cart</h1>
+                {cartItems.length === 0 ? (
+                    <MessageBox>
+                        Cart is empty. <Link to="/">Go Shopping</Link>
+                    </MessageBox>
+                ) : (
+                    <ul>
+                        {cartItems.map((item) => (
+                            <li key={item.product}>
+                                <div className="row">
+                                    <div>
+                                        <img
+                                            src={item.image}
+                                            alt={item.name}
+                                            className="small"
+                                        />
+                                    </div>
+                                    <div className="min-30">
+                                        <Link to={`/product/${item.product}`}>{item.name}</Link>
+                                    </div>
+                                    <div>
+                                        <select
+                                            value={item.qty}
+                                            onChange={(e) =>
+                                                dispatch(
+                                                    addToCart(item.product, Number(e.target.value))
+                                                )
+                                            }
+                                        >
+                                            {[...Array(item.countInStock).keys()].map((x) => (
+                                                <option key={x + 1} value={x + 1}>
+                                                    {x + 1}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    <div>${item.price}</div>
+                                    <div>
+                                        <button
+                                            type="button"
+                                            onClick={() => removeFromCartHandler(item.product)}
+                                        >
+                                            Delete
+                                        </button>
+                                    </div>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+            <div className="col-1">
+                <div className="card card-body">
+                    <ul>
+                        <li>
+                            <h2>
+                                Subtotal ({cartItems.reduce((a, c) => a + Number(c.qty), 0)} items) : $
+                                {cartItems.reduce((a, c) => a + c.price * Number(c.qty), 0)}
+                            </h2>
+                        </li>
+                        <li>
+                            <button
+                                type="button"
+                                onClick={checkoutHandler}
+                                className="primary block"
+                                disabled={cartItems.length === 0}
+                            >
+                                Proceed to Checkout
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default CartScreen;

--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, Number(e.target.value)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}


### PR DESCRIPTION
This pull request resolves a critical bug highlighted in the ticket regarding the shopping cart's subtotal calculation. Previously, item quantities were concatenated as strings instead of being summed as integers, leading to inaccurate subtotal displays (e.g., 'subtotal 121 items' instead of 'subtotal 4 items').

**Key Changes:**
- Ensured that item quantities are explicitly converted to integers before summation in the cart's subtotal and total item count calculations.
- Modified the `onChange` handler for the quantity select element to cast the selected quantity to an integer before dispatching the `addToCart` action.

These changes rectify the subtotal calculation issue, ensuring that the subtotal correctly sums the quantities of all items in the cart. This fix enhances the accuracy of the cart's calculations, thereby improving user trust and experience during the checkout process.