### PR TITLE
Fix Incorrect Subtotal Calculation in Shopping Cart

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,18 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, parseInt(e.target.value, 10)))}>
+                    <select value={item.qty} onChange={(e) => {
+                      try {
+                        const parsedValue = parseInt(e.target.value, 10);
+                        if (!isNaN(parsedValue)) {
+                          dispatch(addToCart(item.product, parsedValue));
+                        } else {
+                          console.error(`Parsing error: Qty value is not a number.`);
+                        }
+                      } catch (error) {
+                        console.error(`Error changing quantity: ${error.message}`, error);
+                      }
+                    }}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}

--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -55,7 +55,7 @@ function CartScreen(props) {
                   </div>
                   <div>
                     Qty:
-                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, e.target.value))}>
+                  <select value={item.qty} onChange={(e) => dispatch(addToCart(item.product, parseInt(e.target.value, 10)))}>
                       {[...Array(item.countInStock).keys()].map(x =>
                         <option key={x + 1} value={x + 1}>{x + 1}</option>
                       )}
@@ -76,9 +76,9 @@ function CartScreen(props) {
     </div>
     <div className="cart-action">
       <h3>
-        Subtotal ( {cartItems.reduce((a, c) => a + c.qty, 0)} items)
+        Subtotal ( {cartItems.reduce((a, c) => a + parseInt(c.qty, 10), 0)} items)
         :
-         $ {cartItems.reduce((a, c) => a + c.price * c.qty, 0)}
+         $ {cartItems.reduce((a, c) => a + c.price * parseInt(c.qty, 10), 0)}
       </h3>
       <button onClick={checkoutHandler} className="button primary full-width" disabled={cartItems.length === 0}>
         Proceed to Checkout


### PR DESCRIPTION
This pull request addresses the issue where adjusting the quantities of items in the shopping cart led to incorrect subtotal calculations. Instead of summing the quantities numerically, the application concatenated them as strings, resulting in misleading subtotal counts.

**Key Changes:**

1. Ensured that item quantities are parsed as integers before being summed to calculate the subtotal. This change was made in the `CartScreen.js` file, specifically within the subtotal calculation logic.

2. Modified the event handler for changing item quantities in the cart to parse the selected quantity as an integer before dispatching the `addToCart` action. This prevents any potential type mismatch by ensuring quantities are treated as integers throughout the application's flow.

These adjustments correct the subtotal calculation, enhancing the reliability of the cart functionality and improving the overall user experience on the e-commerce platform.